### PR TITLE
Add meal plan history

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -184,6 +184,21 @@ main {
   font-weight: 500;
 }
 
+/* Historical meal tables */
+.meal-history {
+  margin-top: 1rem;
+}
+
+.history-week {
+  margin-bottom: 1rem;
+}
+
+.history-week summary {
+  cursor: pointer;
+  padding: 0.25rem 0;
+  font-weight: 600;
+}
+
 /* ==================================================
      5) RECIPES / CARDS
      ================================================== */

--- a/src/MealHistory.jsx
+++ b/src/MealHistory.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react';
+import { collection, onSnapshot } from 'firebase/firestore';
+import { db } from './firebase';
+import { format } from 'date-fns';
+
+export default function MealHistory() {
+  const user = { uid: 'sharedFamily' };
+  const plansRef = collection(db, 'families', user.uid, 'mealPlans');
+
+  const [weeks, setWeeks] = useState([]);
+  useEffect(() =>
+    onSnapshot(plansRef, snap => {
+      const arr = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+      arr.sort((a, b) => (a.id < b.id ? 1 : -1));
+      setWeeks(arr);
+    }),
+  []);
+
+  const currentWeek = format(new Date(), 'yyyy‑II');
+  const days  = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche'];
+  const times = ['midi','soir'];
+
+  const history = weeks.filter(w => w.id !== currentWeek);
+
+  if (history.length === 0) {
+    return (
+      <section className="meal-history">
+        <h3>Historique des repas</h3>
+        <p>Aucun historique.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="meal-history">
+      <h3>Historique des repas</h3>
+      {history.map(week => (
+        <details key={week.id} className="history-week">
+          <summary>Semaine {week.id}</summary>
+          <table className="meal-table">
+            <thead>
+              <tr>
+                <th>Jour</th>
+                {times.map(t => <th key={t}>{t}</th>)}
+              </tr>
+            </thead>
+            <tbody>
+              {days.map(day => (
+                <tr key={day}>
+                  <td>{day}</td>
+                  {times.map(t => (
+                    <td key={t}>
+                      <span>{week[day]?.[t] || '—'}</span>
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
+      ))}
+    </section>
+  );
+}

--- a/src/MealPlan.jsx
+++ b/src/MealPlan.jsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { doc, onSnapshot, setDoc, deleteDoc } from 'firebase/firestore';
 import { db } from './firebase';
 import { format } from 'date-fns';
+import MealHistory from './MealHistory';
 
 export default function MealPlan() {
   const user = { uid: 'sharedFamily' };
@@ -50,6 +51,7 @@ export default function MealPlan() {
       <button className="clear-plan-btn" onClick={clearPlan}>
         Effacer le planning
       </button>
+      <MealHistory />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- track all meal plan weeks in Firestore
- show past weeks under the menu
- style history tables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849dc02740c8321b58f1ec6f21e4632