### PR TITLE
Affiche les plats passés en cartes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -189,6 +189,25 @@ main {
   margin-top: 1rem;
 }
 
+/* Liste d'idées de repas */
+.ideas-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dish-card {
+  background: #2A2A2A;
+  padding: 0.5rem 0.75rem;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.dish-card:hover {
+  background: #333;
+}
+
 .history-week {
   margin-bottom: 1rem;
 }

--- a/src/MealHistory.jsx
+++ b/src/MealHistory.jsx
@@ -22,10 +22,19 @@ export default function MealHistory() {
 
   const history = weeks.filter(w => w.id !== currentWeek);
 
-  if (history.length === 0) {
+  // Récupère la liste unique des plats précédemment planifiés
+  const pastDishes = Array.from(
+    new Set(
+      history.flatMap(week =>
+        days.flatMap(d => times.map(t => week[d]?.[t]).filter(Boolean))
+      )
+    )
+  ).sort((a, b) => a.localeCompare(b, 'fr', { sensitivity: 'base' }));
+
+  if (pastDishes.length === 0) {
     return (
       <section className="meal-history">
-        <h3>Historique des repas</h3>
+        <h3>Plats précédents</h3>
         <p>Aucun historique.</p>
       </section>
     );
@@ -33,32 +42,12 @@ export default function MealHistory() {
 
   return (
     <section className="meal-history">
-      <h3>Historique des repas</h3>
-      {history.map(week => (
-        <details key={week.id} className="history-week">
-          <summary>Semaine {week.id}</summary>
-          <table className="meal-table">
-            <thead>
-              <tr>
-                <th>Jour</th>
-                {times.map(t => <th key={t}>{t}</th>)}
-              </tr>
-            </thead>
-            <tbody>
-              {days.map(day => (
-                <tr key={day}>
-                  <td>{day}</td>
-                  {times.map(t => (
-                    <td key={t}>
-                      <span>{week[day]?.[t] || '—'}</span>
-                    </td>
-                  ))}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </details>
-      ))}
+      <h3>Plats précédents</h3>
+      <div className="ideas-list">
+        {pastDishes.map(dish => (
+          <div key={dish} className="dish-card">{dish}</div>
+        ))}
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Notes
- Lint et build échouent car les dépendances ne sont pas installées dans l'environnement.

## Summary
- extraire l'historique des repas et en faire une liste de plats uniques
- afficher ces plats sous forme de cartes rappelant la liste de courses
- styles CSS pour `ideas-list` et `dish-card`

## Testing
- `npm run lint` *(échoue : package `@eslint/js` manquant)*
- `npm run build` *(échoue : `vite` introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_6849de15b6f48321aa75d8931fc6c543