### PR TITLE
Add meal plan drag-and-drop

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -162,6 +162,10 @@ main {
   background: #333;
 }
 
+.meal-table td.dragover {
+  background: #555;
+}
+
 .meal-table td button {
   position: absolute;
   top: 4px;

--- a/src/MealHistory.jsx
+++ b/src/MealHistory.jsx
@@ -45,7 +45,16 @@ export default function MealHistory() {
       <h3>Plats précédents</h3>
       <div className="ideas-list">
         {pastDishes.map(dish => (
-          <div key={dish} className="dish-card">{dish}</div>
+          <div
+            key={dish}
+            className="dish-card"
+            draggable
+            onDragStart={e => {
+              e.dataTransfer.setData('text/plain', dish)
+            }}
+          >
+            {dish}
+          </div>
         ))}
       </div>
     </section>

--- a/src/MealPlan.jsx
+++ b/src/MealPlan.jsx
@@ -26,6 +26,20 @@ export default function MealPlan() {
   };
   const clearPlan = ()=> setDoc(planRef, {});
 
+  const allowDrop = e => e.preventDefault();
+  const highlight = e => e.currentTarget.classList.add('dragover');
+  const unhighlight = e => e.currentTarget.classList.remove('dragover');
+  const onDrop = async (day, time, e) => {
+    e.preventDefault();
+    unhighlight(e);
+    const dish = e.dataTransfer.getData('text/plain');
+    if (!dish) return;
+    await setDoc(planRef, {
+      ...plan,
+      [day]: { ...plan[day], [time]: dish }
+    });
+  };
+
   return (
     <>
       <table className="meal-table">
@@ -40,7 +54,14 @@ export default function MealPlan() {
             <tr key={day}>
               <td>{day}</td>
               {times.map(t=>(
-                <td key={t} onClick={()=>edit(day,t)}>
+                <td
+                  key={t}
+                  onClick={()=>edit(day,t)}
+                  onDragOver={allowDrop}
+                  onDragEnter={highlight}
+                  onDragLeave={unhighlight}
+                  onDrop={e => onDrop(day, t, e)}
+                >
                   <span>{plan[day]?.[t]||'—'}</span>
                 </td>
               ))}


### PR DESCRIPTION
## Summary
- allow dragging past dishes into meal table cells
- highlight cells during dragover

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849e2ee4e248321b1b463e1e14070ac