### PR TITLE
Add family login with local persistence

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -521,3 +521,27 @@ main {
   cursor: pointer;
   font-size: 1rem;
 }
+
+/* ==================================================
+     LOGIN SCREEN
+     ================================================== */
+.login-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 3rem;
+}
+
+.login-screen form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.login-screen input {
+  padding: 0.5rem;
+  border: 1px solid #333;
+  background: #2A2A2A;
+  border-radius: 4px;
+  color: #EEE;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,16 +1,17 @@
 // src/App.jsx
-import { useState } from 'react'
+import { useState, useContext } from 'react'
 import './App.css'
-import { FamilyProvider } from './FamilyContext'
+import { FamilyProvider, FamilyCtx } from './FamilyContext'
 import ShoppingList from './ShoppingList'
 import MealPlan from './MealPlan'
 import Recipes from './Recipes'
 
-export default function App() {
-  const [page, setPage] = useState('shopping') // 'shopping' | 'meal' | 'recipes'
+function AppContent() {
+  const { logout } = useContext(FamilyCtx)
+  const [page, setPage] = useState('shopping')
 
   return (
-    <FamilyProvider>
+    <>
       {/* Barre de navigation */}
       <div className="navbar-wrapper">
         <nav className="navbar">
@@ -35,6 +36,7 @@ export default function App() {
           >
             📒 Recettes
           </a>
+          <button className="btn-small" onClick={logout}>Déconnexion</button>
         </nav>
       </div>
 
@@ -56,6 +58,14 @@ export default function App() {
           </section>
         )}
       </main>
+    </>
+  )
+}
+
+export default function App() {
+  return (
+    <FamilyProvider>
+      <AppContent />
     </FamilyProvider>
   )
 }

--- a/src/FamilyContext.jsx
+++ b/src/FamilyContext.jsx
@@ -1,13 +1,27 @@
 // src/FamilyContext.jsx
 import { createContext, useEffect, useState } from 'react'
-import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth'
-import { auth } from './firebase'  // votre getAuth(app)
+import { signInAnonymously, onAuthStateChanged } from 'firebase/auth'
+import {
+  collection,
+  doc,
+  getDocs,
+  setDoc
+} from 'firebase/firestore'
+import { auth, db } from './firebase'
 
-export const FamilyCtx = createContext(null)
+const DEFAULT_FAMILY_ID = 'sharedFamily'
+
+export const FamilyCtx = createContext({
+  user: null,
+  familyId: null,
+  logout: () => {}
+})
 
 export function FamilyProvider({ children }) {
   const [user, setUser] = useState(null)
+  const [familyId, setFamilyId] = useState(() => localStorage.getItem('familyId') || '')
   const [loading, setLoading] = useState(true)
+  const [draft, setDraft] = useState('')
 
   useEffect(() => {
     // Lancer la connexion anonyme à chaque chargement
@@ -31,8 +45,62 @@ export function FamilyProvider({ children }) {
     return <div>🔄 Chargement…</div>
   }
 
+  const login = id => {
+    const value = id.trim()
+    if (!value) return
+    localStorage.setItem('familyId', value)
+    setFamilyId(value)
+  }
+
+  const createFamily = async id => {
+    const value = id.trim()
+    if (!value) return
+    const subCols = ['shoppingItems', 'mealPlans', 'recipes']
+    for (const sub of subCols) {
+      const snap = await getDocs(collection(db, 'families', DEFAULT_FAMILY_ID, sub))
+      await Promise.all(
+        snap.docs.map(docSnap =>
+          setDoc(doc(db, 'families', value, sub, docSnap.id), docSnap.data())
+        )
+      )
+    }
+    localStorage.setItem('familyId', value)
+    setFamilyId(value)
+  }
+
+  const logout = () => {
+    localStorage.removeItem('familyId')
+    setFamilyId('')
+  }
+
+  if (!familyId) {
+    return (
+      <div className="login-screen">
+        <form onSubmit={e => { e.preventDefault(); login(draft) }}>
+          <h2>Connexion famille</h2>
+          <input
+            type="text"
+            placeholder="Identifiant famille"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+          />
+          <button type="submit">Entrer</button>
+          <button
+            type="button"
+            onClick={() => {
+              const id = prompt('Nouvel identifiant famille ?')
+              if (id) createFamily(id)
+            }}
+          >
+            Créer une famille
+          </button>
+        </form>
+      </div>
+    )
+  }
+
   return (
-    <FamilyCtx.Provider value={user}>
+    <FamilyCtx.Provider value={{ user, familyId, logout }}>
       {children}
     </FamilyCtx.Provider>
   )

--- a/src/MealHistory.jsx
+++ b/src/MealHistory.jsx
@@ -1,11 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { collection, onSnapshot } from 'firebase/firestore';
 import { db } from './firebase';
 import { format } from 'date-fns';
+import { FamilyCtx } from './FamilyContext';
 
 export default function MealHistory() {
-  const user = { uid: 'sharedFamily' };
-  const plansRef = collection(db, 'families', user.uid, 'mealPlans');
+  const { familyId } = useContext(FamilyCtx);
+  const plansRef = collection(db, 'families', familyId, 'mealPlans');
 
   const [weeks, setWeeks] = useState([]);
   useEffect(() =>

--- a/src/MealPlan.jsx
+++ b/src/MealPlan.jsx
@@ -1,14 +1,15 @@
 // src/MealPlan.jsx
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useContext } from 'react';
 import { doc, onSnapshot, setDoc, deleteDoc } from 'firebase/firestore';
 import { db } from './firebase';
 import { format } from 'date-fns';
 import MealHistory from './MealHistory';
+import { FamilyCtx } from './FamilyContext';
 
 export default function MealPlan() {
-  const user = { uid: 'sharedFamily' };
+  const { familyId } = useContext(FamilyCtx);
   const week = format(new Date(), 'yyyy‑II');
-  const planRef = doc(db, 'families', user.uid, 'mealPlans', week);
+  const planRef = doc(db, 'families', familyId, 'mealPlans', week);
   const days = ['Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi','Dimanche'];
   const times = ['midi','soir'];
 

--- a/src/Recipes.jsx
+++ b/src/Recipes.jsx
@@ -1,5 +1,5 @@
 // src/Recipes.jsx
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState, useContext } from 'react'
 import {
   collection,
   onSnapshot,
@@ -9,12 +9,13 @@ import {
   doc
 } from 'firebase/firestore'
 import { db } from './firebase'
+import { FamilyCtx } from './FamilyContext'
 import './Recipes.css'
 import { query, orderBy } from 'firebase/firestore'
 
 export default function Recipes() {
-  const FAMILY_ID = 'sharedFamily'
-  const colRef = collection(db, 'families', FAMILY_ID, 'recipes')
+  const { familyId } = useContext(FamilyCtx)
+  const colRef = collection(db, 'families', familyId, 'recipes')
   const q      = query(colRef, orderBy('title'))     // tri alphabétique par titre
 
   const [recipes, setRecipes]         = useState([])
@@ -74,7 +75,7 @@ export default function Recipes() {
   // save all edits
   async function saveAll() {
     if (!selected) return
-    const ref = doc(db, 'families', FAMILY_ID, 'recipes', selected.id)
+    const ref = doc(db, 'families', familyId, 'recipes', selected.id)
     await updateDoc(ref, {
       title: draftTitle,
       ingredients: draftIngredients,
@@ -96,7 +97,7 @@ export default function Recipes() {
   async function deleteCurrent() {
     if (!selected) return
     if (confirm('Supprimer cette recette ?')) {
-      await deleteDoc(doc(db, 'families', FAMILY_ID, 'recipes', selected.id))
+      await deleteDoc(doc(db, 'families', familyId, 'recipes', selected.id))
       setSelected(null)
     }
   }

--- a/src/ShoppingList.jsx
+++ b/src/ShoppingList.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useRef } from 'react'
+import { useEffect, useState, useRef, useContext } from 'react'
 import {
   collection,
   query,
@@ -11,10 +11,11 @@ import {
 } from 'firebase/firestore'
 import { signInAnonymously, onAuthStateChanged } from 'firebase/auth'
 import { db, auth } from './firebase'
+import { FamilyCtx } from './FamilyContext'
 import './ShoppingList.css'
 
 export default function ShoppingList() {
-  const FAMILY_ID = 'sharedFamily'
+  const { familyId } = useContext(FamilyCtx)
   const [items, setItems] = useState([])
   const [newItemName, setNewItemName] = useState('')
   const [editingFrequent, setEditingFrequent] = useState(false)
@@ -26,7 +27,7 @@ export default function ShoppingList() {
     let unsubSnapshot
     const unsubAuth = onAuthStateChanged(auth, user => {
       if (!user) return
-      const col = collection(db, 'families', FAMILY_ID, 'shoppingItems')
+      const col = collection(db, 'families', familyId, 'shoppingItems')
       const q = query(col, orderBy('createdAt'))
       unsubSnapshot = onSnapshot(
         q,
@@ -38,7 +39,7 @@ export default function ShoppingList() {
       unsubAuth()
       unsubSnapshot?.()
     }
-  }, [])
+  }, [familyId])
 
   // Categorize items
   const purchased = items
@@ -59,7 +60,7 @@ export default function ShoppingList() {
     const name = newItemName.trim()
     if (!name) return
     await addDoc(
-      collection(db, 'families', FAMILY_ID, 'shoppingItems'),
+      collection(db, 'families', familyId, 'shoppingItems'),
       {
         name,
         checked: false,
@@ -78,27 +79,27 @@ export default function ShoppingList() {
   // Toggle bought
   const toggleChecked = item =>
     updateDoc(
-      doc(db, 'families', FAMILY_ID, 'shoppingItems', item.id),
+      doc(db, 'families', familyId, 'shoppingItems', item.id),
       { checked: !item.checked }
     )
 
   // Remove from favorites
   const removeFavorite = item =>
     updateDoc(
-      doc(db, 'families', FAMILY_ID, 'shoppingItems', item.id),
+      doc(db, 'families', familyId, 'shoppingItems', item.id),
       { favored: false }
     )
 
   // Toggle favorite
   const toggleFavored = item =>
     updateDoc(
-      doc(db, 'families', FAMILY_ID, 'shoppingItems', item.id),
+      doc(db, 'families', familyId, 'shoppingItems', item.id),
       { favored: !item.favored }
     )
 
   // Delete item
   const removeItem = item =>
-    deleteDoc(doc(db, 'families', FAMILY_ID, 'shoppingItems', item.id))
+    deleteDoc(doc(db, 'families', familyId, 'shoppingItems', item.id))
 
   return (
     <div className="shopping-container">


### PR DESCRIPTION
## Summary
- add a login screen and remember the selected family
- show a logout button in the navigation bar
- use the selected family in shopping list, meal plan, meal history and recipes
- style the login page
- add a family creation button that clones data from `sharedFamily`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0f55390832198b07683a1f2b3aa