### PR TITLE
Add image support for recipes

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -295,6 +295,14 @@ main {
   hyphens: auto;
 }
 
+.card-thumb {
+  width: 100%;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+}
+
 .card-title {
   font-size: 1.1rem;
   font-weight: 600;
@@ -369,6 +377,14 @@ main {
   border: 1px solid #333;
   border-radius: 4px;
   color: #EEE;
+}
+
+.overlay-image {
+  width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+  border-radius: 6px;
+  margin-bottom: 1rem;
 }
 
 /* ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
@@ -520,4 +536,15 @@ main {
   border-radius: 4px;
   cursor: pointer;
   font-size: 1rem;
+}
+
+.btn-remove-img {
+  background: #F44336;
+  color: #fff;
+  padding: 0.3rem 0.6rem;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
 }

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,7 +1,8 @@
 // src/firebase.js
 import { initializeApp } from 'firebase/app'
 import { getFirestore, enableIndexedDbPersistence } from 'firebase/firestore'
-import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth';
+import { getAuth, signInAnonymously, onAuthStateChanged } from 'firebase/auth'
+import { getStorage } from 'firebase/storage'
 
 
 
@@ -42,6 +43,7 @@ onAuthStateChanged(auth, user => {
 });
 
 export const db = getFirestore(app)
+export const storage = getStorage(app)
 
 // 3. Active le cache offline
 enableIndexedDbPersistence(db).catch(err => {


### PR DESCRIPTION
## Summary
- extend Firebase config with Storage
- style recipe images in lists and overlay
- store image URL in recipe schema and import logic
- handle image upload/removal and display in Recipes UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849fd080a348321b835194b2bd2604d