### PR TITLE
Fix image persistence

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,21 @@ export default defineConfig({
       devOptions: {
         enabled: isDev
       },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/firebasestorage\.googleapis\.com\/.*$/,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'firebase-images',
+              expiration: {
+                maxEntries: 50,
+                maxAgeSeconds: 60 * 60 * 24 * 30 // 30 days
+              }
+            }
+          }
+        ]
+      },
       manifest: {
         name: 'Ma PWA Test',
         short_name: 'TestPWA',


### PR DESCRIPTION
## Summary
- cache images from Firebase Storage so they stay available offline

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684a03d7d9b88321beb099f881735577