### PR TITLE
Support new recipe import format

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,7 +4,7 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 
 export default [
-  { ignores: ['dist'] },
+  { ignores: ['dist', 'dev-dist'] },
   {
     files: ['**/*.{js,jsx}'],
     languageOptions: {


### PR DESCRIPTION
## Summary
- Parse pasted recipes using the new format with servings line, dot-separated ingredients, and step list
- Hint new format in the import textarea placeholder
- Ignore dev-dist build artifacts during linting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars in existing files)*
- `npx eslint src/Recipes.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68c15eb846e08321a6c74a999cad3670